### PR TITLE
fix: next auth secret key error in vercel

### DIFF
--- a/src/shared/lib/auth/auth.ts
+++ b/src/shared/lib/auth/auth.ts
@@ -18,6 +18,7 @@ declare module 'next-auth' {
 
 export const authOptions: AuthOptions = {
   adapter: PrismaAdapter(prisma),
+  secret: process.env.NEXTAUTH_SECRET,
   providers: [
     CredentialsProvider({
       name: 'Credentials',


### PR DESCRIPTION
authOptions 설정: NEXTAUTH_SECRET 환경 변수를 사용해 secret 속성을 추가.